### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "main.py"

--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 NLP lab to try out with binder 
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/sislandemarcos/NLP-lab/master)
+
+[![Run on Repl.it](https://repl.it/badge/github/sislandemarcos/NLP-lab)](https://repl.it/github/sislandemarcos/NLP-lab)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@MarcosSilva11/NLP-lab-1).